### PR TITLE
YDA-6415: Increase contrast in measure labels

### DIFF
--- a/ckanext/cd2_theme/fanstatic/cd2_custom.css
+++ b/ckanext/cd2_theme/fanstatic/cd2_custom.css
@@ -938,6 +938,8 @@ h8 {
 }
 .info-hover {
   cursor: help;
+  color: #fff;
+  background-color: #6e6e6e;
 }
 .pointer {
   cursor: pointer!important;
@@ -1252,8 +1254,8 @@ a:active {
   white-space: nowrap;
 }
 .cohort-spanner {
-  background-color: #ddd;
-  color: #000;
+  background-color: #ccc;
+  color: #fff;
   padding: 0px 5px;
   border-radius: 5px;
   line-height: 200%;
@@ -1428,6 +1430,8 @@ body .site-footer hr {
 }
 .label-info {
   line-height: 24px;
+  color: #fff;
+  background-color: #117799!important;
 }
 body {
   background-color: #fff;


### PR DESCRIPTION
Adjust labels of measures so that they have white letters on a dark background, in order to improve text readability.